### PR TITLE
Fix toast from scrolling the page on mobile

### DIFF
--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -68,4 +68,5 @@ dialog {
   background-color: transparent;
   top: 0;
   padding: var(--space-300);
+  position: fixed;
 }


### PR DESCRIPTION
This commit sets the dialog element to `position: fixed` so that it is anchored to the viewport, not the page.