### PR TITLE
Improve toast screenreader a11y

### DIFF
--- a/src/assets/js/toast.js
+++ b/src/assets/js/toast.js
@@ -11,6 +11,7 @@ class Toast {
   startFadeOut(delay = 5000) {
     this.timeout = setTimeout(() => {
       this.toast.classList.add('fade-out')
+      this.dialog.setAttribute('aria-live', 'off')
     }, delay);
   }
 
@@ -20,6 +21,7 @@ class Toast {
   }
 
   show() {
+    this.dialog.setAttribute('aria-live', 'assertive')
     this.dialog.show()
     this.toast.classList.add('fade-in-top')
     this.startFadeOut()

--- a/src/index.html
+++ b/src/index.html
@@ -98,7 +98,7 @@
       </form>
     </article>
 
-    <dialog>
+    <dialog role="alert" aria-live="assertive">
       <div class="toast" data-js-hook="success">
         <h2>
           <svg viewBox="0 0 20 21" width="20" height="21" aria-hidden="true">


### PR DESCRIPTION
This commit includes two changes:

- I added `role="alert"` and `aria-live="assertive"` to the dialog element, so screenreaders will announce it when it appears.

- The toast fades out after a five-second delay. Upon testing on Safari iOS VoiceOver, the contents of the dialog are anounced again when the fade out animation begins. Not sure if this is a bug, but to work around this issue, I updated the Toast class to set the `aria-live` attribute to `off` when the fade out animation starts, and to set it back to `assertive` when the dialog is shown.